### PR TITLE
Fix popup timer and cover it with tests

### DIFF
--- a/cypress.json
+++ b/cypress.json
@@ -3,5 +3,6 @@
   "watchForFileChanges": false,
   "viewportWidth": 1600,
   "viewportHeight": 1400,
-  "chromeWebSecurity": false
+  "chromeWebSecurity": false,
+  "$schema": "https://on.cypress.io/cypress.schema.json"
 }


### PR DESCRIPTION
Popup now shows after 10 minutes automatically only after unsuccessful confirmation or after closing without confirmation.
Added and repaired tests to cover this behavior.
Fixed a bug where fetchPopup() was not called in showPopup().